### PR TITLE
fix: added a more enforceable fragment dismiss

### DIFF
--- a/android/src/main/java/io/rownd/android/views/HubComposableBottomSheet.kt
+++ b/android/src/main/java/io/rownd/android/views/HubComposableBottomSheet.kt
@@ -38,7 +38,7 @@ class HubComposableBottomSheet : ComposableBottomSheetFragment() {
     // Internal dismiss function to recycle web view
     private fun _dismiss() {
         viewModel?.webView()?.postValue(null)
-        dismiss()
+        dismissAllowingStateLoss()
     }
 
     @OptIn(ExperimentalMaterialApi::class)


### PR DESCRIPTION
When disimiss() is called with the app running in the background
![Screen Shot 2023-01-19 at 9 20 40 AM](https://user-images.githubusercontent.com/53702681/213466290-dbb7b3e3-892b-4983-a510-b16fa694f55b.png)

**Result:** The second time the app comes back from being in the background, the Rownd bottom sheet is stuck
![Screenshot_20230119-092153](https://user-images.githubusercontent.com/53702681/213466724-42d31dd5-284d-4912-a0f1-582bb19d6a69.png)
