### PR TITLE
fix(users): prevent refreshing user record when in background

### DIFF
--- a/android/src/main/java/io/rownd/android/models/RowndHubInteropMessage.kt
+++ b/android/src/main/java/io/rownd/android/models/RowndHubInteropMessage.kt
@@ -34,6 +34,12 @@ enum class MessageType {
     CreatePasskey,
     @SerialName("trigger_sign_in_with_passkey")
     AuthenticateWithPasskey,
+    @SerialName("hub_loaded")
+    HubLoaded,
+    @SerialName("hub_resize")
+    HubResize,
+    @SerialName("can_touch_background_to_dismiss")
+    CanTouchBackgroundToDismiss,
     unknown
 }
 
@@ -96,6 +102,35 @@ data class SignInWithPasskeyMessage(
     override var type: MessageType = MessageType.AuthenticateWithPasskey
 ) : RowndHubInteropMessage()
 
+@Serializable
+data class HubLoaded(
+    override var type: MessageType = MessageType.HubLoaded
+) : RowndHubInteropMessage()
+
+@Serializable
+data class HubResizeMessage(
+    override var type: MessageType = MessageType.HubResize,
+    var payload: HubResizePayload
+) : RowndHubInteropMessage()
+
+@Serializable
+data class HubResizePayload(
+    @SerialName("height")
+    var height: String
+)
+
+@Serializable
+data class CanTouchBackgroundToDismissMessage(
+    override var type: MessageType = MessageType.CanTouchBackgroundToDismiss,
+    var payload: CanTouchBackgroundToDismissPayload
+) : RowndHubInteropMessage()
+
+@Serializable
+data class CanTouchBackgroundToDismissPayload(
+    @SerialName("enable")
+    var enable: String
+)
+
 object RowndHubInteropMessageSerializer : JsonContentPolymorphicSerializer<RowndHubInteropMessage>(RowndHubInteropMessage::class) {
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out RowndHubInteropMessage> {
         return when (val messageType = element.jsonObject["type"]?.jsonPrimitive?.content) {
@@ -107,6 +142,9 @@ object RowndHubInteropMessageSerializer : JsonContentPolymorphicSerializer<Rownd
             "close_hub_view_controller" -> CloseHubViewMessage.serializer()
             "trigger_sign_up_with_passkey" -> SignUpWithPasskeyMessage.serializer()
             "trigger_sign_in_with_passkey" -> SignInWithPasskeyMessage.serializer()
+            "hub_loaded" -> HubLoaded.serializer()
+            "hub_resize" -> HubResizeMessage.serializer()
+            "can_touch_background_to_dismiss" -> CanTouchBackgroundToDismissMessage.serializer()
             else -> throw Error("Key '$messageType' did not match a known serializer.")
         }
     }

--- a/android/src/main/java/io/rownd/android/models/repos/StateRepo.kt
+++ b/android/src/main/java/io/rownd/android/models/repos/StateRepo.kt
@@ -13,6 +13,7 @@ import io.rownd.android.models.domain.AppConfigState
 import io.rownd.android.models.domain.AuthState
 import io.rownd.android.models.domain.SignInState
 import io.rownd.android.models.domain.User
+import io.rownd.android.util.AppLifecycleListener
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
@@ -123,8 +124,8 @@ class StateRepo @Inject constructor() {
                 }
             }
 
-            // Fetch latest user data if we're authenticated
-            if (store.currentState.auth.isAccessTokenValid) {
+            // Fetch latest user data if we're authenticated and app is in foreground
+            if (AppLifecycleListener.isAppInForeground && store.currentState.auth.isAccessTokenValid) {
                 userRepo.loadUserAsync().await()
             }
 

--- a/android/src/main/java/io/rownd/android/util/AppLifecycleListener.kt
+++ b/android/src/main/java/io/rownd/android/util/AppLifecycleListener.kt
@@ -61,6 +61,7 @@ class AppLifecycleListener(parentApp: Application) : ActivityLifecycleCallbacks 
 
     override fun onActivityResumed(activity: Activity) {
         this.activity = WeakReference(activity)
+        isAppInForeground = true
 
         // This is probably one of the better trigger points for listeners
         // unless there's a need for something earlier in the lifecycle
@@ -83,7 +84,9 @@ class AppLifecycleListener(parentApp: Application) : ActivityLifecycleCallbacks 
         }
     }
 
-    override fun onActivityPaused(activity: Activity) {}
+    override fun onActivityPaused(activity: Activity) {
+        isAppInForeground = false
+    }
     override fun onActivityStopped(activity: Activity) {}
     override fun onActivitySaveInstanceState(activity: Activity, bundle: Bundle) {}
     override fun onActivityDestroyed(activity: Activity) {
@@ -115,5 +118,9 @@ class AppLifecycleListener(parentApp: Application) : ActivityLifecycleCallbacks 
         } else if (immediate && activity != null) {
             callback.invoke(activity)
         }
+    }
+
+    companion object {
+        var isAppInForeground: Boolean = false
     }
 }

--- a/android/src/main/java/io/rownd/android/views/RowndWebView.kt
+++ b/android/src/main/java/io/rownd/android/views/RowndWebView.kt
@@ -343,6 +343,18 @@ class RowndJavascriptInterface(
                     parentWebView.rowndClient.requestSignIn(with = RowndSignInHint.Passkey)
                 }
 
+                MessageType.HubLoaded -> {
+                    Log.d("RowndHub", "Message 'hub_loaded' isn't supported yet")
+                }
+
+                MessageType.HubResize -> {
+                    Log.d("RowndHub", "Message 'hub_resize' isn't supported yet")
+                }
+
+                MessageType.CanTouchBackgroundToDismiss -> {
+                    Log.d("RowndHub", "Message 'can_touch_background_to_dismiss' isn't supported yet")
+                }
+
                 else -> {
                     Log.w("RowndHub", "An unknown message was received")
                 }


### PR DESCRIPTION
If the app isn't in the foreground, we don't need to refresh the user record.