### PR TITLE
feat: improve passkey sdk apis

### DIFF
--- a/android/src/main/java/io/rownd/android/Rownd.kt
+++ b/android/src/main/java/io/rownd/android/Rownd.kt
@@ -40,7 +40,9 @@ import dagger.Component
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerAuthProvider
 import io.ktor.client.plugins.plugin
+import io.rownd.android.authenticators.passkeys.PasskeyAuthentication
 import io.rownd.android.authenticators.passkeys.PasskeysCommon
+import io.rownd.android.models.AuthenticatorType
 import io.rownd.android.models.RowndAuthenticatorRegistrationOptions
 import io.rownd.android.models.RowndConfig
 import io.rownd.android.models.RowndConnectionAction
@@ -359,6 +361,21 @@ class RowndClient constructor(
     @Suppress("unused")
     fun requestSignIn() {
         displayHub(HubPageSelector.SignIn)
+    }
+
+    inner class Auth {
+        inner class Passkeys {
+            fun register() {
+                displayHub(
+                    targetPage = HubPageSelector.ConnectAuthenticator,
+                    jsFnOptions = RowndAuthenticatorRegistrationOptions(type = AuthenticatorType.Passkey)
+                )
+            }
+
+            fun authenticate() {
+                appHandleWrapper?.activity?.get()?.let { passkeyAuthenticator.authentication.authenticate(it) }
+            }
+        }
     }
 
     fun signOut() {

--- a/android/src/main/java/io/rownd/android/Rownd.kt
+++ b/android/src/main/java/io/rownd/android/Rownd.kt
@@ -363,8 +363,8 @@ class RowndClient constructor(
         displayHub(HubPageSelector.SignIn)
     }
 
-    inner class Auth {
-        inner class Passkeys {
+    inner class auth {
+        inner class passkeys {
             fun register() {
                 displayHub(
                     targetPage = HubPageSelector.ConnectAuthenticator,

--- a/android/src/main/java/io/rownd/android/authenticators/passkeys/Registration.kt
+++ b/android/src/main/java/io/rownd/android/authenticators/passkeys/Registration.kt
@@ -9,12 +9,19 @@ import androidx.credentials.CredentialManager
 import androidx.credentials.exceptions.CreateCredentialException
 import io.ktor.client.call.*
 import io.ktor.client.request.*
+import io.ktor.utils.io.core.toByteArray
 import io.rownd.android.models.PasskeyStatus
 import io.rownd.android.models.RowndAuthenticatorRegistrationOptions
+import io.rownd.android.models.json
+import io.rownd.android.util.toBase64
 import io.rownd.android.views.HubPageSelector
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 class PasskeyRegistration constructor(private val passkeys: PasskeysCommon) {
 
@@ -22,6 +29,23 @@ class PasskeyRegistration constructor(private val passkeys: PasskeysCommon) {
 
     private val rowndContext = passkeys.rowndContext
     private val authenticatedApi = passkeys.authenticatedApi
+
+    private fun modifyRequestJson(requestJsonString: String): String {
+        val requestJsonElement = json.parseToJsonElement(requestJsonString)
+
+        var requestJsonObject = requestJsonElement.jsonObject
+        val userId = requestJsonObject["user"]?.jsonObject?.get("id")?.jsonPrimitive?.content
+            ?: throw Exception("Missing user id")
+
+        // Modifies user.id to use base-64 encoded value
+        requestJsonObject = JsonObject(requestJsonObject.toMutableMap().apply {
+            put("user", JsonObject(requestJsonObject["user"]?.jsonObject?.toMutableMap()?.apply {
+                put("id", JsonPrimitive(userId.toByteArray().toBase64()))
+            } ?: mutableMapOf()))
+        })
+
+        return requestJsonObject.toString().trim()
+    }
 
     fun register(activity: Activity) {
         val jsFnOptions = RowndAuthenticatorRegistrationOptions(
@@ -34,10 +58,11 @@ class PasskeyRegistration constructor(private val passkeys: PasskeysCommon) {
 
         CoroutineScope(Dispatchers.IO).launch {
             try {
+                val requestJson: String = modifyRequestJson(fetchRegistrationOptions(passkeys.computeRpId()))
                 val createPublicKeyCredentialRequest = CreatePublicKeyCredentialRequest(
                     // Contains the request in JSON format. Uses the standard WebAuthn
                     // web JSON spec.
-                    requestJson = fetchRegistrationOptions(passkeys.computeRpId()),
+                    requestJson = requestJson,
                     // Defines whether you prefer to use only immediately available credentials,
                     // not hybrid credentials, to fulfill this request. This value is false
                     // by default.
@@ -53,12 +78,20 @@ class PasskeyRegistration constructor(private val passkeys: PasskeysCommon) {
 
                         Log.d("Rownd.passkeys", result.type)
                         handlePasskeyRegistrationResult(result)
-                    } catch (e : Exception) {
+                    }
+                    catch (e : CreateCredentialException){
+                        val errorMessage = e.errorMessage
+                        // Handle cancellation from user
+                        if (errorMessage?.contains("Unable to get sync account") == true) {
+                            handleCancellation(e)
+                            return@launch
+                        }
+                        handleFailure(e)
+                    }
+                    catch (e : Exception) {
                         handleFailure(e)
                     }
                 }
-            } catch (e : CreateCredentialException){
-                handleFailure(e)
             } catch (e : Exception) {
                 handleFailure(e)
             }
@@ -116,6 +149,16 @@ class PasskeyRegistration constructor(private val passkeys: PasskeysCommon) {
             }
         }
     }
+    private fun handleCancellation(e: CreateCredentialException) {
+        // Hide bottom sheet
+        CoroutineScope(Dispatchers.Main).launch {
+            val hubWebView = rowndContext.hubViewModel?.webView()?.value
+            if (hubWebView?.isAttachedToWindow == true) {
+                hubWebView.dismiss?.invoke()
+            }
+        }
+    }
+
 
     private fun handleFailure(e: Exception) {
         Log.e(TAG, "Something went wrong during passkey registration", e)

--- a/android/src/main/java/io/rownd/android/authenticators/passkeys/Registration.kt
+++ b/android/src/main/java/io/rownd/android/authenticators/passkeys/Registration.kt
@@ -52,6 +52,11 @@ class PasskeyRegistration constructor(private val passkeys: PasskeysCommon) {
             status = PasskeyStatus.Loading
         )
 
+        if (rowndContext.store?.currentState?.auth?.isAuthenticated != true) {
+            Log.e(TAG, "Need to be authenticated to register a passkey")
+            return
+        }
+
         displayRegistrationStatus(jsFnOptions)
 
         val credentialManager = CredentialManager.create(activity)


### PR DESCRIPTION
- Add passkey specific api's `rownd.Auth.Passkeys.register()` and `rownd.Auth.Passkeys.authenticate()`
- Replace userId with base64 encoded string for requestJson