### PR TITLE
feat: allow disabling sign-in link behavior

### DIFF
--- a/android/src/main/java/io/rownd/android/models/RowndConfig.kt
+++ b/android/src/main/java/io/rownd/android/models/RowndConfig.kt
@@ -31,6 +31,8 @@ data class RowndConfig(
     var forceInstantUserConversion: Boolean = false,
     @Transient
     var enableDebugMode: Boolean = false,
+    @Transient
+    var enableSmartLinkPasteBehavior: Boolean = true,
 
     // Internals
     @Transient
@@ -74,4 +76,3 @@ data class RowndConfig(
         return uriBuilder.build().toString()
     }
 }
-

--- a/android/src/main/java/io/rownd/android/models/network/SignInLink.kt
+++ b/android/src/main/java/io/rownd/android/models/network/SignInLink.kt
@@ -65,6 +65,9 @@ class SignInLinkApi @Inject constructor() {
     @Inject
     lateinit var apiClient: KtorApiClient
 
+    @Inject
+    lateinit var config: io.rownd.android.models.RowndConfig
+
     suspend fun createSignInLink() : SignInLink {
         return authenticatedApiClient.client.post("me/auth/magic").body()
     }
@@ -129,13 +132,15 @@ class SignInLinkApi @Inject constructor() {
 
         if (action == ACTION_VIEW && isRowndSignInLink(ctx.intent?.data)) {
             dispatchSignInWithLink(ctx.intent?.data)
-        } else if (ctx.hasWindowFocus()) {
-            // Look on the clipboard
-            signInWithLinkFromClipboardIfPresent(ctx)
-        } else {
-            val rootView = ctx.findViewById<View>(android.R.id.content)
-            rootView.doOnLayout {
+        } else if (config.enableSmartLinkPasteBehavior) {
+            if (ctx.hasWindowFocus()) {
+                // Look on the clipboard
                 signInWithLinkFromClipboardIfPresent(ctx)
+            } else {
+                val rootView = ctx.findViewById<View>(android.R.id.content)
+                rootView.doOnLayout {
+                    signInWithLinkFromClipboardIfPresent(ctx)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a configuration flag to enable or disable automatic magic link sign-in from the clipboard and apply it in the sign-in link flow.

Enhancements:
- Add enableSmartLinkPasteBehavior flag to RowndConfig with default true and inject RowndConfig into SignInLinkApi.
- Guard the automatic clipboard-based sign-in behavior on the new configuration flag in SignInLinkApi.