### PR TITLE
Add the SuperTokens lazy migration flow

### DIFF
--- a/android/src/main/java/io/rownd/android/Rownd.kt
+++ b/android/src/main/java/io/rownd/android/Rownd.kt
@@ -40,7 +40,6 @@ import io.rownd.android.util.NoRefreshTokenPresentException
 import io.rownd.android.util.RowndEvent
 import io.rownd.android.util.RowndEventType
 import io.rownd.android.util.RowndException
-import io.rownd.android.util.syncUserToSuperTokens
 import io.rownd.android.views.HubPageSelector
 import io.rownd.android.views.RowndBottomSheetActivity
 import io.rownd.android.views.RowndWebViewModel
@@ -78,6 +77,7 @@ class RowndClient(
     internal var eventEmitter = graph.rowndEventEmitter()
     internal var signInWithGoogle = graph.signInWithGoogle()
     internal var telemetry = graph.telemetry()
+    internal var superTokensSync = graph.superTokensSync()
 
     var state = stateRepo.state
     var user = userRepo
@@ -104,7 +104,7 @@ class RowndClient(
             val appInfo = config.supertokens?.appInfo ?: return@addListener
 
             CoroutineScope(Dispatchers.IO).launch {
-                syncUserToSuperTokens(accessToken = accessToken, appInfo = appInfo)
+                superTokensSync.syncUser(accessToken = accessToken, appInfo = appInfo)
             }
         }
 

--- a/android/src/main/java/io/rownd/android/Rownd.kt
+++ b/android/src/main/java/io/rownd/android/Rownd.kt
@@ -38,7 +38,9 @@ import io.rownd.android.util.InvalidRefreshTokenException
 import io.rownd.android.util.NoAccessTokenPresentException
 import io.rownd.android.util.NoRefreshTokenPresentException
 import io.rownd.android.util.RowndEvent
+import io.rownd.android.util.RowndEventType
 import io.rownd.android.util.RowndException
+import io.rownd.android.util.syncUserToSuperTokens
 import io.rownd.android.views.HubPageSelector
 import io.rownd.android.views.RowndBottomSheetActivity
 import io.rownd.android.views.RowndWebViewModel
@@ -88,6 +90,23 @@ class RowndClient(
         rowndContext.store = stateRepo.getStore()
         rowndContext.eventEmitter = eventEmitter
         rowndContext.telemetry = telemetry
+
+        eventEmitter.addListener { event ->
+            if (event.event != RowndEventType.SignInCompleted || event.data["user_type"] != "new_user") {
+                return@addListener
+            }
+
+            if (!this::store.isInitialized) {
+                return@addListener
+            }
+
+            val accessToken = store.currentState.auth.accessToken ?: return@addListener
+            val appInfo = config.supertokens?.appInfo ?: return@addListener
+
+            CoroutineScope(Dispatchers.IO).launch {
+                syncUserToSuperTokens(accessToken = accessToken, appInfo = appInfo)
+            }
+        }
 
         stateRepo.userRepo = userRepo
         stateRepo.authRepo = authRepo

--- a/android/src/main/java/io/rownd/android/di/component/RowndComponent.kt
+++ b/android/src/main/java/io/rownd/android/di/component/RowndComponent.kt
@@ -19,6 +19,7 @@ import io.rownd.android.util.RowndContext
 import io.rownd.android.util.RowndEvent
 import io.rownd.android.util.RowndEventEmitter
 import io.rownd.android.util.SignInWithGoogle
+import io.rownd.android.util.SuperTokensSync
 import io.rownd.android.util.Telemetry
 import io.rownd.android.util.TokenApiClient
 import javax.inject.Singleton
@@ -44,6 +45,7 @@ interface RowndGraph {
     fun rowndEventEmitter(): RowndEventEmitter<RowndEvent>
     fun signInWithGoogle(): SignInWithGoogle
     fun telemetry(): Telemetry
+    fun superTokensSync(): SuperTokensSync
     fun tokenApiClient(): TokenApiClient
     fun authenticatedApiClient(): AuthenticatedApiClient
     fun httpEngine(): HttpClientEngine

--- a/android/src/main/java/io/rownd/android/models/RowndConfig.kt
+++ b/android/src/main/java/io/rownd/android/models/RowndConfig.kt
@@ -16,6 +16,18 @@ import javax.inject.Inject
 val json = Json { encodeDefaults = true }
 
 @Serializable
+data class SuperTokensAppInfo(
+    val appName: String,
+    val apiDomain: String,
+    val apiBasePath: String = "/auth"
+)
+
+@Serializable
+data class SuperTokensConfig(
+    val appInfo: SuperTokensAppInfo
+)
+
+@Serializable
 data class RowndConfig(
     var appKey: String? = null,
     var baseUrl: String = "https://hub.rownd.io",
@@ -33,6 +45,9 @@ data class RowndConfig(
     var enableDebugMode: Boolean = false,
     @Transient
     var enableSmartLinkPasteBehavior: Boolean = true,
+
+    @Transient
+    var supertokens: SuperTokensConfig? = null,
 
     // Internals
     @Transient

--- a/android/src/main/java/io/rownd/android/models/RowndConfig.kt
+++ b/android/src/main/java/io/rownd/android/models/RowndConfig.kt
@@ -20,7 +20,20 @@ data class SuperTokensAppInfo(
     val appName: String,
     val apiDomain: String,
     val apiBasePath: String = "/auth"
-)
+) {
+    val normalizedApiDomain: String
+        get() = apiDomain.trimEnd('/')
+
+    val normalizedApiBasePath: String
+        get() {
+            val basePath = apiBasePath.trim().trim('/')
+            return if (basePath.isEmpty()) "" else "/$basePath"
+        }
+
+    fun migrationUrl(): String {
+        return "${normalizedApiDomain}${normalizedApiBasePath}/plugin/rownd/migrate"
+    }
+}
 
 @Serializable
 data class SuperTokensConfig(

--- a/android/src/main/java/io/rownd/android/util/SuperTokensSync.kt
+++ b/android/src/main/java/io/rownd/android/util/SuperTokensSync.kt
@@ -1,0 +1,28 @@
+package io.rownd.android.util
+
+import android.util.Log
+import io.rownd.android.models.SuperTokensAppInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+
+suspend fun syncUserToSuperTokens(
+    accessToken: String,
+    appInfo: SuperTokensAppInfo,
+) = withContext(Dispatchers.IO) {
+    val base = "${appInfo.apiDomain}${appInfo.apiBasePath}"
+
+    try {
+        val conn = URL("$base/plugin/rownd/migrate").openConnection() as HttpURLConnection
+        conn.requestMethod = "POST"
+        conn.setRequestProperty("Authorization", "Bearer $accessToken")
+        val code = conn.responseCode
+        if (code !in 200..299) {
+            Log.e("Rownd.ST", "[Rownd->ST] migrate failed with status: $code")
+        }
+        conn.disconnect()
+    } catch (e: Exception) {
+        Log.e("Rownd.ST", "[Rownd->ST] migrate failed (non-fatal): ${e.message}")
+    }
+}

--- a/android/src/main/java/io/rownd/android/util/SuperTokensSync.kt
+++ b/android/src/main/java/io/rownd/android/util/SuperTokensSync.kt
@@ -1,28 +1,25 @@
 package io.rownd.android.util
 
 import android.util.Log
+import io.ktor.client.request.header
+import io.ktor.client.request.post
 import io.rownd.android.models.SuperTokensAppInfo
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-import java.net.HttpURLConnection
-import java.net.URL
+import javax.inject.Inject
+import javax.inject.Singleton
 
-suspend fun syncUserToSuperTokens(
-    accessToken: String,
-    appInfo: SuperTokensAppInfo,
-) = withContext(Dispatchers.IO) {
-    val base = "${appInfo.apiDomain}${appInfo.apiBasePath}"
+@Singleton
+class SuperTokensSync @Inject constructor(
+    private val apiClient: KtorApiClient,
+) {
+    suspend fun syncUser(accessToken: String, appInfo: SuperTokensAppInfo) {
+        val migrationUrl = appInfo.migrationUrl()
 
-    try {
-        val conn = URL("$base/plugin/rownd/migrate").openConnection() as HttpURLConnection
-        conn.requestMethod = "POST"
-        conn.setRequestProperty("Authorization", "Bearer $accessToken")
-        val code = conn.responseCode
-        if (code !in 200..299) {
-            Log.e("Rownd.ST", "[Rownd->ST] migrate failed with status: $code")
+        try {
+            apiClient.client.post(migrationUrl) {
+                header("Authorization", "Bearer $accessToken")
+            }
+        } catch (e: Exception) {
+            Log.e("Rownd.ST", "[Rownd->ST] migrate failed (non-fatal): ${e.message}")
         }
-        conn.disconnect()
-    } catch (e: Exception) {
-        Log.e("Rownd.ST", "[Rownd->ST] migrate failed (non-fatal): ${e.message}")
     }
 }


### PR DESCRIPTION
## Summary

Adds SuperTokens lazy user migration support to the Android SDK.
When the SuperTokens config is passed aand a Rownd sign-in completes for a `new_user`, the SDK now calls the `${apiBasePath}/plugin/rownd/migrate` endpoint.

Sync flow:
- The app opts into migration by setting `Rownd.config.supertokens` with the SuperTokens app info.
- `Rownd` registers an event listener for `SignInCompleted`.
- When a sign-in completes for a `new_user`, the SDK reads the current Rownd access token from state.
- The SDK calls the SuperTokens migration endpoint at

## Summary by Sourcery

Add support for lazily migrating newly created Rownd users to SuperTokens when configured.

New Features:
- Introduce SuperTokens configuration options on Android, including app info and API paths, via RowndConfig.
- Trigger a SuperTokens migration call after a successful sign-in for newly created users when SuperTokens is configured.

Enhancements:
- Add a utility function to invoke the SuperTokens migration endpoint using the current Rownd access token.